### PR TITLE
feat:Add optional expire boolean property to image request schemas in OpenAPI

### DIFF
--- a/src/libs/Recraft/Generated/Recraft.IImageClient.CreativeUpscale.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.CreativeUpscale.g.cs
@@ -17,6 +17,7 @@ namespace Recraft
         /// <summary>
         /// Creative Upscale
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -26,6 +27,7 @@ namespace Recraft
         global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> CreativeUpscaleAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default);

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.CrispUpscale.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.CrispUpscale.g.cs
@@ -17,6 +17,7 @@ namespace Recraft
         /// <summary>
         /// Crisp Upscale
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -26,6 +27,7 @@ namespace Recraft
         global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> CrispUpscaleAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default);

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.EraseRegion.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.EraseRegion.g.cs
@@ -17,6 +17,7 @@ namespace Recraft
         /// <summary>
         /// Erase Region
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -30,6 +31,7 @@ namespace Recraft
             string imagename,
             byte[] mask,
             string maskname,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default);

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.GenerateImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.GenerateImage.g.cs
@@ -20,6 +20,7 @@ namespace Recraft
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
         /// <param name="controls"></param>
+        /// <param name="expire"></param>
         /// <param name="imageFormat"></param>
         /// <param name="model"></param>
         /// <param name="n"></param>
@@ -39,6 +40,7 @@ namespace Recraft
             bool? blockNsfw = default,
             bool? calculateFeatures = default,
             global::Recraft.UserControls? controls = default,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.TransformModel? model = default,
             int? n = default,

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.ImageToImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.ImageToImage.g.cs
@@ -20,6 +20,7 @@ namespace Recraft
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
         /// <param name="controls"></param>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -44,6 +45,7 @@ namespace Recraft
             bool? blockNsfw = default,
             bool? calculateFeatures = default,
             global::Recraft.UserControls? controls = default,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.TransformModel? model = default,
             int? n = default,

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.RemoveBackground.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.RemoveBackground.g.cs
@@ -17,6 +17,7 @@ namespace Recraft
         /// <summary>
         /// Remove background
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -26,6 +27,7 @@ namespace Recraft
         global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> RemoveBackgroundAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default);

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.ReplaceBackground.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.ReplaceBackground.g.cs
@@ -19,6 +19,7 @@ namespace Recraft
         /// </summary>
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -40,6 +41,7 @@ namespace Recraft
             string prompt,
             bool? blockNsfw = default,
             bool? calculateFeatures = default,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.TransformModel? model = default,
             int? n = default,

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.VectorizeImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.VectorizeImage.g.cs
@@ -17,6 +17,7 @@ namespace Recraft
         /// <summary>
         /// Vectorize image
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -26,6 +27,7 @@ namespace Recraft
         global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> VectorizeImageAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default);

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.CreativeUpscale.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.CreativeUpscale.g.cs
@@ -67,6 +67,12 @@ namespace Recraft
                 }
             }
             using var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -180,6 +186,7 @@ namespace Recraft
         /// <summary>
         /// Creative Upscale
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -189,12 +196,14 @@ namespace Recraft
         public async global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> CreativeUpscaleAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Recraft.ProcessImageRequest
             {
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.CrispUpscale.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.CrispUpscale.g.cs
@@ -67,6 +67,12 @@ namespace Recraft
                 }
             }
             using var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -180,6 +186,7 @@ namespace Recraft
         /// <summary>
         /// Crisp Upscale
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -189,12 +196,14 @@ namespace Recraft
         public async global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> CrispUpscaleAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Recraft.ProcessImageRequest
             {
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.EraseRegion.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.EraseRegion.g.cs
@@ -67,6 +67,12 @@ namespace Recraft
                 }
             }
             using var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -184,6 +190,7 @@ namespace Recraft
         /// <summary>
         /// Erase Region
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -197,12 +204,14 @@ namespace Recraft
             string imagename,
             byte[] mask,
             string maskname,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Recraft.EraseRegionRequest
             {
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.GenerateImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.GenerateImage.g.cs
@@ -171,6 +171,7 @@ namespace Recraft
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
         /// <param name="controls"></param>
+        /// <param name="expire"></param>
         /// <param name="imageFormat"></param>
         /// <param name="model"></param>
         /// <param name="n"></param>
@@ -190,6 +191,7 @@ namespace Recraft
             bool? blockNsfw = default,
             bool? calculateFeatures = default,
             global::Recraft.UserControls? controls = default,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.TransformModel? model = default,
             int? n = default,
@@ -208,6 +210,7 @@ namespace Recraft
                 BlockNsfw = blockNsfw,
                 CalculateFeatures = calculateFeatures,
                 Controls = controls,
+                Expire = expire,
                 ImageFormat = imageFormat,
                 Model = model,
                 N = n,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.ImageToImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.ImageToImage.g.cs
@@ -85,6 +85,12 @@ namespace Recraft
                     content: new global::System.Net.Http.StringContent($"{request.Controls}"),
                     name: "controls");
             } 
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -255,6 +261,7 @@ namespace Recraft
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
         /// <param name="controls"></param>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -279,6 +286,7 @@ namespace Recraft
             bool? blockNsfw = default,
             bool? calculateFeatures = default,
             global::Recraft.UserControls? controls = default,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.TransformModel? model = default,
             int? n = default,
@@ -296,6 +304,7 @@ namespace Recraft
                 BlockNsfw = blockNsfw,
                 CalculateFeatures = calculateFeatures,
                 Controls = controls,
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.RemoveBackground.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.RemoveBackground.g.cs
@@ -67,6 +67,12 @@ namespace Recraft
                 }
             }
             using var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -180,6 +186,7 @@ namespace Recraft
         /// <summary>
         /// Remove background
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -189,12 +196,14 @@ namespace Recraft
         public async global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> RemoveBackgroundAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Recraft.ProcessImageRequest
             {
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.ReplaceBackground.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.ReplaceBackground.g.cs
@@ -79,6 +79,12 @@ namespace Recraft
                     content: new global::System.Net.Http.StringContent($"{request.CalculateFeatures}"),
                     name: "calculate_features");
             } 
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -245,6 +251,7 @@ namespace Recraft
         /// </summary>
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -266,6 +273,7 @@ namespace Recraft
             string prompt,
             bool? blockNsfw = default,
             bool? calculateFeatures = default,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.TransformModel? model = default,
             int? n = default,
@@ -282,6 +290,7 @@ namespace Recraft
             {
                 BlockNsfw = blockNsfw,
                 CalculateFeatures = calculateFeatures,
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.VectorizeImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.VectorizeImage.g.cs
@@ -67,6 +67,12 @@ namespace Recraft
                 }
             }
             using var __httpRequestContent = new global::System.Net.Http.MultipartFormDataContent();
+            if (request.Expire != default)
+            {
+                __httpRequestContent.Add(
+                    content: new global::System.Net.Http.StringContent($"{request.Expire}"),
+                    name: "expire");
+            } 
             __httpRequestContent.Add(
                 content: new global::System.Net.Http.ByteArrayContent(request.Image ?? global::System.Array.Empty<byte>()),
                 name: "image",
@@ -180,6 +186,7 @@ namespace Recraft
         /// <summary>
         /// Vectorize image
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -189,12 +196,14 @@ namespace Recraft
         public async global::System.Threading.Tasks.Task<global::Recraft.ProcessImageResponse> VectorizeImageAsync(
             byte[] image,
             string imagename,
+            bool? expire = default,
             global::Recraft.ImageFormat? imageFormat = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::System.Threading.CancellationToken cancellationToken = default)
         {
             var __request = new global::Recraft.ProcessImageRequest
             {
+                Expire = expire,
                 Image = image,
                 Imagename = imagename,
                 ImageFormat = imageFormat,

--- a/src/libs/Recraft/Generated/Recraft.Models.EraseRegionRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.EraseRegionRequest.g.cs
@@ -11,6 +11,12 @@ namespace Recraft
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expire")]
+        public bool? Expire { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("image")]
         [global::System.Text.Json.Serialization.JsonRequired]
         public required byte[] Image { get; set; }
@@ -59,6 +65,7 @@ namespace Recraft
         /// <summary>
         /// Initializes a new instance of the <see cref="EraseRegionRequest" /> class.
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -73,6 +80,7 @@ namespace Recraft
             string imagename,
             byte[] mask,
             string maskname,
+            bool? expire,
             global::Recraft.ImageFormat? imageFormat,
             global::Recraft.ResponseFormat? responseFormat)
         {
@@ -80,6 +88,7 @@ namespace Recraft
             this.Imagename = imagename ?? throw new global::System.ArgumentNullException(nameof(imagename));
             this.Mask = mask ?? throw new global::System.ArgumentNullException(nameof(mask));
             this.Maskname = maskname ?? throw new global::System.ArgumentNullException(nameof(maskname));
+            this.Expire = expire;
             this.ImageFormat = imageFormat;
             this.ResponseFormat = responseFormat;
         }

--- a/src/libs/Recraft/Generated/Recraft.Models.GenerateImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.GenerateImageRequest.g.cs
@@ -29,6 +29,12 @@ namespace Recraft
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expire")]
+        public bool? Expire { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("image_format")]
         [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Recraft.JsonConverters.ImageFormatJsonConverter))]
         public global::Recraft.ImageFormat? ImageFormat { get; set; }
@@ -117,6 +123,7 @@ namespace Recraft
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
         /// <param name="controls"></param>
+        /// <param name="expire"></param>
         /// <param name="imageFormat"></param>
         /// <param name="model"></param>
         /// <param name="n"></param>
@@ -137,6 +144,7 @@ namespace Recraft
             bool? blockNsfw,
             bool? calculateFeatures,
             global::Recraft.UserControls? controls,
+            bool? expire,
             global::Recraft.ImageFormat? imageFormat,
             global::Recraft.TransformModel? model,
             int? n,
@@ -153,6 +161,7 @@ namespace Recraft
             this.BlockNsfw = blockNsfw;
             this.CalculateFeatures = calculateFeatures;
             this.Controls = controls;
+            this.Expire = expire;
             this.ImageFormat = imageFormat;
             this.Model = model;
             this.N = n;

--- a/src/libs/Recraft/Generated/Recraft.Models.ImageToImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.ImageToImageRequest.g.cs
@@ -29,6 +29,12 @@ namespace Recraft
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expire")]
+        public bool? Expire { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("image")]
         [global::System.Text.Json.Serialization.JsonRequired]
         public required byte[] Image { get; set; }
@@ -131,6 +137,7 @@ namespace Recraft
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
         /// <param name="controls"></param>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -156,6 +163,7 @@ namespace Recraft
             bool? blockNsfw,
             bool? calculateFeatures,
             global::Recraft.UserControls? controls,
+            bool? expire,
             global::Recraft.ImageFormat? imageFormat,
             global::Recraft.TransformModel? model,
             int? n,
@@ -174,6 +182,7 @@ namespace Recraft
             this.BlockNsfw = blockNsfw;
             this.CalculateFeatures = calculateFeatures;
             this.Controls = controls;
+            this.Expire = expire;
             this.ImageFormat = imageFormat;
             this.Model = model;
             this.N = n;

--- a/src/libs/Recraft/Generated/Recraft.Models.ProcessImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.ProcessImageRequest.g.cs
@@ -11,6 +11,12 @@ namespace Recraft
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expire")]
+        public bool? Expire { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("image")]
         [global::System.Text.Json.Serialization.JsonRequired]
         public required byte[] Image { get; set; }
@@ -45,6 +51,7 @@ namespace Recraft
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessImageRequest" /> class.
         /// </summary>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -55,11 +62,13 @@ namespace Recraft
         public ProcessImageRequest(
             byte[] image,
             string imagename,
+            bool? expire,
             global::Recraft.ImageFormat? imageFormat,
             global::Recraft.ResponseFormat? responseFormat)
         {
             this.Image = image ?? throw new global::System.ArgumentNullException(nameof(image));
             this.Imagename = imagename ?? throw new global::System.ArgumentNullException(nameof(imagename));
+            this.Expire = expire;
             this.ImageFormat = imageFormat;
             this.ResponseFormat = responseFormat;
         }

--- a/src/libs/Recraft/Generated/Recraft.Models.TransformImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.TransformImageRequest.g.cs
@@ -23,6 +23,12 @@ namespace Recraft
         /// <summary>
         /// 
         /// </summary>
+        [global::System.Text.Json.Serialization.JsonPropertyName("expire")]
+        public bool? Expire { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("image")]
         [global::System.Text.Json.Serialization.JsonRequired]
         public required byte[] Image { get; set; }
@@ -117,6 +123,7 @@ namespace Recraft
         /// </summary>
         /// <param name="blockNsfw"></param>
         /// <param name="calculateFeatures"></param>
+        /// <param name="expire"></param>
         /// <param name="image"></param>
         /// <param name="imagename"></param>
         /// <param name="imageFormat"></param>
@@ -139,6 +146,7 @@ namespace Recraft
             string prompt,
             bool? blockNsfw,
             bool? calculateFeatures,
+            bool? expire,
             global::Recraft.ImageFormat? imageFormat,
             global::Recraft.TransformModel? model,
             int? n,
@@ -155,6 +163,7 @@ namespace Recraft
             this.Prompt = prompt ?? throw new global::System.ArgumentNullException(nameof(prompt));
             this.BlockNsfw = blockNsfw;
             this.CalculateFeatures = calculateFeatures;
+            this.Expire = expire;
             this.ImageFormat = imageFormat;
             this.Model = model;
             this.N = n;

--- a/src/libs/Recraft/openapi.yaml
+++ b/src/libs/Recraft/openapi.yaml
@@ -389,6 +389,8 @@ components:
         - mask
       type: object
       properties:
+        expire:
+          type: boolean
         image:
           type: string
           format: binary
@@ -410,6 +412,8 @@ components:
           type: boolean
         controls:
           $ref: '#/components/schemas/UserControls'
+        expire:
+          type: boolean
         image_format:
           $ref: '#/components/schemas/ImageFormat'
         model:
@@ -644,6 +648,8 @@ components:
           type: boolean
         controls:
           $ref: '#/components/schemas/UserControls'
+        expire:
+          type: boolean
         image:
           type: string
           format: binary
@@ -700,6 +706,8 @@ components:
         - image
       type: object
       properties:
+        expire:
+          type: boolean
         image:
           type: string
           format: binary
@@ -787,6 +795,8 @@ components:
         block_nsfw:
           type: boolean
         calculate_features:
+          type: boolean
+        expire:
           type: boolean
         image:
           type: string


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional "expire" setting to various image processing and generation requests, allowing users to specify if images should expire after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->