### PR TITLE
feat:OpenAPI: change style property from enum to string in image requests

### DIFF
--- a/src/libs/Recraft/Generated/Recraft.IImageClient.GenerateImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.GenerateImage.g.cs
@@ -48,7 +48,7 @@ namespace Recraft
             int? randomSeed = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::Recraft.ImageSize? size = default,
-            global::Recraft.ImageStyle? style = default,
+            string? style = default,
             global::System.Guid? styleId = default,
             global::Recraft.ImageSubStyle? substyle = default,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout = default,

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.ImageToImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.ImageToImage.g.cs
@@ -52,7 +52,7 @@ namespace Recraft
             string? negativePrompt = default,
             int? randomSeed = default,
             global::Recraft.ResponseFormat? responseFormat = default,
-            global::Recraft.ImageStyle? style = default,
+            string? style = default,
             global::System.Guid? styleId = default,
             global::Recraft.ImageSubStyle? substyle = default,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout = default,

--- a/src/libs/Recraft/Generated/Recraft.IImageClient.ReplaceBackground.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.IImageClient.ReplaceBackground.g.cs
@@ -48,7 +48,7 @@ namespace Recraft
             string? negativePrompt = default,
             int? randomSeed = default,
             global::Recraft.ResponseFormat? responseFormat = default,
-            global::Recraft.ImageStyle? style = default,
+            string? style = default,
             global::System.Guid? styleId = default,
             global::Recraft.ImageSubStyle? substyle = default,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout = default,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.GenerateImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.GenerateImage.g.cs
@@ -199,7 +199,7 @@ namespace Recraft
             int? randomSeed = default,
             global::Recraft.ResponseFormat? responseFormat = default,
             global::Recraft.ImageSize? size = default,
-            global::Recraft.ImageStyle? style = default,
+            string? style = default,
             global::System.Guid? styleId = default,
             global::Recraft.ImageSubStyle? substyle = default,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout = default,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.ImageToImage.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.ImageToImage.g.cs
@@ -140,7 +140,7 @@ namespace Recraft
             if (request.Style != default)
             {
                 __httpRequestContent.Add(
-                    content: new global::System.Net.Http.StringContent($"{request.Style?.ToValueString()}"),
+                    content: new global::System.Net.Http.StringContent($"{request.Style}"),
                     name: "style");
             } 
             if (request.StyleId != default)
@@ -293,7 +293,7 @@ namespace Recraft
             string? negativePrompt = default,
             int? randomSeed = default,
             global::Recraft.ResponseFormat? responseFormat = default,
-            global::Recraft.ImageStyle? style = default,
+            string? style = default,
             global::System.Guid? styleId = default,
             global::Recraft.ImageSubStyle? substyle = default,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout = default,

--- a/src/libs/Recraft/Generated/Recraft.ImageClient.ReplaceBackground.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.ImageClient.ReplaceBackground.g.cs
@@ -131,7 +131,7 @@ namespace Recraft
             if (request.Style != default)
             {
                 __httpRequestContent.Add(
-                    content: new global::System.Net.Http.StringContent($"{request.Style?.ToValueString()}"),
+                    content: new global::System.Net.Http.StringContent($"{request.Style}"),
                     name: "style");
             } 
             if (request.StyleId != default)
@@ -280,7 +280,7 @@ namespace Recraft
             string? negativePrompt = default,
             int? randomSeed = default,
             global::Recraft.ResponseFormat? responseFormat = default,
-            global::Recraft.ImageStyle? style = default,
+            string? style = default,
             global::System.Guid? styleId = default,
             global::Recraft.ImageSubStyle? substyle = default,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout = default,

--- a/src/libs/Recraft/Generated/Recraft.Models.GenerateImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.GenerateImageRequest.g.cs
@@ -89,8 +89,7 @@ namespace Recraft
         /// 
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("style")]
-        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Recraft.JsonConverters.ImageStyleJsonConverter))]
-        public global::Recraft.ImageStyle? Style { get; set; }
+        public string? Style { get; set; }
 
         /// <summary>
         /// 
@@ -152,7 +151,7 @@ namespace Recraft
             int? randomSeed,
             global::Recraft.ResponseFormat? responseFormat,
             global::Recraft.ImageSize? size,
-            global::Recraft.ImageStyle? style,
+            string? style,
             global::System.Guid? styleId,
             global::Recraft.ImageSubStyle? substyle,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout)

--- a/src/libs/Recraft/Generated/Recraft.Models.ImageToImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.ImageToImageRequest.g.cs
@@ -103,8 +103,7 @@ namespace Recraft
         /// 
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("style")]
-        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Recraft.JsonConverters.ImageStyleJsonConverter))]
-        public global::Recraft.ImageStyle? Style { get; set; }
+        public string? Style { get; set; }
 
         /// <summary>
         /// 
@@ -170,7 +169,7 @@ namespace Recraft
             string? negativePrompt,
             int? randomSeed,
             global::Recraft.ResponseFormat? responseFormat,
-            global::Recraft.ImageStyle? style,
+            string? style,
             global::System.Guid? styleId,
             global::Recraft.ImageSubStyle? substyle,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout)

--- a/src/libs/Recraft/Generated/Recraft.Models.TransformImageRequest.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.TransformImageRequest.g.cs
@@ -90,8 +90,7 @@ namespace Recraft
         /// 
         /// </summary>
         [global::System.Text.Json.Serialization.JsonPropertyName("style")]
-        [global::System.Text.Json.Serialization.JsonConverter(typeof(global::Recraft.JsonConverters.ImageStyleJsonConverter))]
-        public global::Recraft.ImageStyle? Style { get; set; }
+        public string? Style { get; set; }
 
         /// <summary>
         /// 
@@ -153,7 +152,7 @@ namespace Recraft
             string? negativePrompt,
             int? randomSeed,
             global::Recraft.ResponseFormat? responseFormat,
-            global::Recraft.ImageStyle? style,
+            string? style,
             global::System.Guid? styleId,
             global::Recraft.ImageSubStyle? substyle,
             global::System.Collections.Generic.IList<global::Recraft.TextLayoutItem>? textLayout)

--- a/src/libs/Recraft/openapi.yaml
+++ b/src/libs/Recraft/openapi.yaml
@@ -432,7 +432,7 @@ components:
         size:
           $ref: '#/components/schemas/ImageSize'
         style:
-          $ref: '#/components/schemas/ImageStyle'
+          type: string
         style_id:
           type: string
           format: uuid
@@ -671,7 +671,7 @@ components:
         strength:
           type: number
         style:
-          $ref: '#/components/schemas/ImageStyle'
+          type: string
         style_id:
           type: string
           format: uuid
@@ -817,7 +817,7 @@ components:
         response_format:
           $ref: '#/components/schemas/ResponseFormat'
         style:
-          $ref: '#/components/schemas/ImageStyle'
+          type: string
         style_id:
           type: string
           format: uuid


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image generation, image-to-image, and transform endpoints now accept free-form style values (strings), enabling custom styles beyond the previous predefined list.
  * Backward compatible: existing predefined styles continue to work.
  * Fewer validation errors when experimenting with new or custom style names.

* **Chores**
  * Updated API specification to reflect relaxed style validation for the affected endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->