### PR TITLE
feat:Add qwen_image and gemini_25_flash_image to TransformModel enum

### DIFF
--- a/src/libs/Recraft/Generated/Recraft.Models.TransformModel.g.cs
+++ b/src/libs/Recraft/Generated/Recraft.Models.TransformModel.g.cs
@@ -80,6 +80,14 @@ namespace Recraft
         /// 
         /// </summary>
         IdeogramV3Quality,
+        /// <summary>
+        /// 
+        /// </summary>
+        QwenImage,
+        /// <summary>
+        /// 
+        /// </summary>
+        Gemini25FlashImage,
     }
 
     /// <summary>
@@ -112,6 +120,8 @@ namespace Recraft
                 TransformModel.IdeogramV3Turbo => "ideogram_v3_turbo",
                 TransformModel.IdeogramV3Default => "ideogram_v3_default",
                 TransformModel.IdeogramV3Quality => "ideogram_v3_quality",
+                TransformModel.QwenImage => "qwen_image",
+                TransformModel.Gemini25FlashImage => "gemini_25_flash_image",
                 _ => throw new global::System.ArgumentOutOfRangeException(nameof(value), value, null),
             };
         }
@@ -140,6 +150,8 @@ namespace Recraft
                 "ideogram_v3_turbo" => TransformModel.IdeogramV3Turbo,
                 "ideogram_v3_default" => TransformModel.IdeogramV3Default,
                 "ideogram_v3_quality" => TransformModel.IdeogramV3Quality,
+                "qwen_image" => TransformModel.QwenImage,
+                "gemini_25_flash_image" => TransformModel.Gemini25FlashImage,
                 _ => null,
             };
         }

--- a/src/libs/Recraft/openapi.yaml
+++ b/src/libs/Recraft/openapi.yaml
@@ -859,6 +859,8 @@ components:
         - ideogram_v3_turbo
         - ideogram_v3_default
         - ideogram_v3_quality
+        - qwen_image
+        - gemini_25_flash_image
       type: string
     User:
       required:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for two new image transformation models: Qwen Image and Gemini 2.5 Flash Image. These models can now be selected wherever transform models are configurable, enabling broader provider choice for image workflows.

- Documentation
  - Updated API specification to include the new model options, ensuring client generators and validators recognize them and that consumers see the expanded model list in API references and any model selection UIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->